### PR TITLE
Split function into Stack Frame Extraction & Printing

### DIFF
--- a/frame.go
+++ b/frame.go
@@ -36,7 +36,7 @@ func ExtractFrames(st errors.StackTrace) Frames {
 }
 
 func (frames Frames) Exclude(excludes Frames) Frames {
-	newFrames := Frames{}
+	newFrames := make(Frames, 0, len(frames))
 
 L1:
 	for _, f := range frames {

--- a/frame.go
+++ b/frame.go
@@ -6,6 +6,12 @@ import (
 	"github.com/pkg/errors"
 )
 
+type ErrorSet struct {
+	Error  error
+	Frames Frames
+	Parent Frames
+}
+
 type Frame struct {
 	File string
 	Line int

--- a/pperr_test.go
+++ b/pperr_test.go
@@ -50,8 +50,8 @@ func TestFprint(t *testing.T) {
 	pperr.Fprint(&buf, err)
 
 	actual := buf.String()
-	actual = regexp.MustCompile(`(?m)[^\s>]+/go/.*:\d+$`).ReplaceAllString(actual, ".../go/...:NN")
 	actual = regexp.MustCompile(`(?m)[^\s>]+/pperr_test.go:\d+$`).ReplaceAllString(actual, ".../pperr_test.go:NN")
+	actual = regexp.MustCompile(`(?m)[^\s>]+/go/.*:\d+$`).ReplaceAllString(actual, ".../go/...:NN")
 	actual = regexp.MustCompile(`(?m):\d+$`).ReplaceAllString(actual, ":NN")
 
 	expected := strings.TrimPrefix(`
@@ -113,8 +113,8 @@ func TestFprint_Indent(t *testing.T) {
 	pperr.FprintFunc(&buf, err, pperr.NewPrinterWithIndent(">>"))
 
 	actual := buf.String()
-	actual = regexp.MustCompile(`(?m)[^\s>]+/go/.*:\d+$`).ReplaceAllString(actual, ".../go/...:NN")
 	actual = regexp.MustCompile(`(?m)[^\s>]+/pperr_test.go:\d+$`).ReplaceAllString(actual, ".../pperr_test.go:NN")
+	actual = regexp.MustCompile(`(?m)[^\s>]+/go/.*:\d+$`).ReplaceAllString(actual, ".../go/...:NN")
 	actual = regexp.MustCompile(`(?m):\d+$`).ReplaceAllString(actual, ":NN")
 
 	expected := strings.TrimPrefix(`
@@ -154,8 +154,8 @@ func TestSprint(t *testing.T) {
 	err := f1(true)
 	actual := pperr.Sprint(err)
 
-	actual = regexp.MustCompile(`(?m)[^\s>]+/go/.*:\d+$`).ReplaceAllString(actual, ".../go/...:NN")
 	actual = regexp.MustCompile(`(?m)[^\s>]+/pperr_test.go:\d+$`).ReplaceAllString(actual, ".../pperr_test.go:NN")
+	actual = regexp.MustCompile(`(?m)[^\s>]+/go/.*:\d+$`).ReplaceAllString(actual, ".../go/...:NN")
 	actual = regexp.MustCompile(`(?m):\d+$`).ReplaceAllString(actual, ":NN")
 
 	expected := strings.TrimPrefix(`
@@ -195,8 +195,8 @@ func TestSprintFunc(t *testing.T) {
 	err := f1(true)
 	actual := pperr.SprintFunc(err, pperr.NewPrinterWithIndent(">>"))
 
-	actual = regexp.MustCompile(`(?m)[^\s>]+/go/.*:\d+$`).ReplaceAllString(actual, ".../go/...:NN")
 	actual = regexp.MustCompile(`(?m)[^\s>]+/pperr_test.go:\d+$`).ReplaceAllString(actual, ".../pperr_test.go:NN")
+	actual = regexp.MustCompile(`(?m)[^\s>]+/go/.*:\d+$`).ReplaceAllString(actual, ".../go/...:NN")
 	actual = regexp.MustCompile(`(?m):\d+$`).ReplaceAllString(actual, ":NN")
 
 	expected := strings.TrimPrefix(`
@@ -261,8 +261,8 @@ func TestFprint_WithoutMessage(t *testing.T) {
 	pperr.FprintFunc(&buf, err, pperr.PrinterWithoutMessage)
 
 	actual := buf.String()
-	actual = regexp.MustCompile(`(?m)[^\s>]+/go/.*:\d+$`).ReplaceAllString(actual, ".../go/...:NN")
 	actual = regexp.MustCompile(`(?m)[^\s>]+/pperr_test.go:\d+$`).ReplaceAllString(actual, ".../pperr_test.go:NN")
+	actual = regexp.MustCompile(`(?m)[^\s>]+/go/.*:\d+$`).ReplaceAllString(actual, ".../go/...:NN")
 	actual = regexp.MustCompile(`(?m):\d+$`).ReplaceAllString(actual, ":NN")
 
 	expected := strings.TrimPrefix(`

--- a/printer.go
+++ b/printer.go
@@ -24,7 +24,7 @@ var DefaultPrinterWithIndent = func(w io.Writer, err error, frames, parent Frame
 	}
 }
 
-var PrinterWithoutMessage = func(w io.Writer, err error, frames, parent Frames) {
+var PrinterWithoutMessage = func(w io.Writer, _ error, frames, parent Frames) {
 	if frames != nil {
 		if parent != nil {
 			frames = frames.Exclude(parent)


### PR DESCRIPTION
Currently, The package provides a function that extracts the stack frame structure and prints it using a printer.

By splitting these functionalities into separate functions and exposing a function for extracting stack frames, it becomes handy for internal analysis of stack frames.